### PR TITLE
Add className and variantDefinitions getter

### DIFF
--- a/__tests__/responsive-recipes.test.ts
+++ b/__tests__/responsive-recipes.test.ts
@@ -19,6 +19,19 @@ describe('runtime recipes', () => {
         'style__1rdq1cn0 style_size_small__1rdq1cn1 style_isDesktop_true__1rdq1cn5'
       );
     });
+
+    it('should return the regular variants when using the variantDefinitions variants getter', () => {
+      expect(stack.variantDefinitions.variants).toEqual({
+        size: { values: ['small', 'large'], defaultValue: undefined },
+        spacing: { values: ['compact', 'normal'], defaultValue: undefined },
+        isDesktop: { values: ['true', 'false'], defaultValue: undefined },
+        amountOfCols: { values: ['0', '12'], defaultValue: undefined }
+      });
+
+      expect(heading.variantDefinitions.variants).toEqual({
+        color: { values: ['red', 'blue'], defaultValue: 'red' }
+      });
+    });
   });
 
   describe('with responsive variants', () => {
@@ -85,6 +98,31 @@ describe('runtime recipes', () => {
       expect(result).toBe(
         'style__1rdq1cn0 style_initial_backgroundColor_green__1rdq1cn9 style_initial_gap_1__1rdq1cnc style_md_gap_2__1rdq1cnn style_lg_gap_3__1rdq1cny'
       );
+    });
+
+    it('should return the correct responsive variants when using the variantDefinitions responsiveVariants getter', () => {
+      expect(stack.variantDefinitions.responsiveVariants).toEqual({
+        backgroundColor: {
+          values: ['green', 'blue', 'red'],
+          defaultValue: undefined
+        },
+        gap: { values: ['1', '2', '3'], defaultValue: undefined },
+        direction: {
+          values: ['row', 'column'],
+          defaultValue: undefined
+        },
+        isFullHeight: {
+          values: ['true', 'false'],
+          defaultValue: undefined
+        }
+      });
+
+      expect(heading.variantDefinitions.responsiveVariants).toEqual({
+        size: {
+          values: ['small', 'large'],
+          defaultValue: 'large'
+        }
+      });
     });
   });
 
@@ -189,5 +227,10 @@ describe('runtime recipes', () => {
         'style__1rdq1cn1n style_sm_size_large__1rdq1cn1r style_xl_size_small__1rdq1cn1s style_color_red__1rdq1cn1o'
       );
     });
+  });
+
+  it('should return a base class when using the className getter', () => {
+    expect(stack.classNames.base).toBe('style__1rdq1cn0');
+    expect(heading.classNames.base).toBe('style__1rdq1cn1n');
   });
 });

--- a/src/lib/buildtimeFn.ts
+++ b/src/lib/buildtimeFn.ts
@@ -33,11 +33,11 @@ export function createRecipe<const DefaultConditions extends Conditions>({
     const config: BuildResult = {
       initialCondition: (options.initialCondition ?? initialCondition) || 'initial',
       conditions,
-      responsiveVariantClassNames: {},
+      baseClassName: '',
       variantClassNames: {},
+      responsiveVariantClassNames: {},
       compoundVariants: [],
-      defaultVariants,
-      baseClassName: ''
+      defaultVariants
     };
 
     // First we generate a basic className for the base styles

--- a/src/lib/createRuntimeFn.ts
+++ b/src/lib/createRuntimeFn.ts
@@ -143,5 +143,39 @@ export function createRuntimeFn<
     return className.join(' ');
   };
 
+  runtimeFn.classNames = {
+    get base() {
+      return buildResult.baseClassName;
+    }
+  };
+
+  function getVariantDefinitions(options: Record<string, Record<string, unknown>>) {
+    type VariantDefinitions = {
+      [index: string]: {
+        values: (string | number)[];
+        defaultValue?: string | number | boolean | undefined;
+      };
+    };
+
+    return Object.entries(options).reduce<VariantDefinitions>((acc, [key, value]) => {
+      acc[key] = { values: Object.keys(value), defaultValue: buildResult.defaultVariants[key] };
+      return acc;
+    }, {});
+  }
+
+  runtimeFn.variantDefinitions = {
+    get variants() {
+      return getVariantDefinitions(buildResult.variantClassNames);
+    },
+
+    get responsiveVariants() {
+      return getVariantDefinitions(buildResult.responsiveVariantClassNames);
+    },
+
+    get defaultVariants() {
+      return buildResult.defaultVariants;
+    }
+  };
+
   return runtimeFn;
 }

--- a/src/lib/createRuntimeFn.ts
+++ b/src/lib/createRuntimeFn.ts
@@ -152,13 +152,17 @@ export function createRuntimeFn<
   function getVariantDefinitions(options: Record<string, Record<string, unknown>>) {
     type VariantDefinitions = {
       [index: string]: {
-        values: (string | number)[];
-        defaultValue?: string | number | boolean | undefined;
+        values: string[];
+        defaultValue?: string;
       };
     };
 
     return Object.entries(options).reduce<VariantDefinitions>((acc, [key, value]) => {
-      acc[key] = { values: Object.keys(value), defaultValue: buildResult.defaultVariants[key] };
+      // Note: Should we parse these values here?
+      acc[key] = {
+        values: Object.keys(value),
+        defaultValue: buildResult.defaultVariants[key]?.toString()
+      };
       return acc;
     }, {});
   }


### PR DESCRIPTION
Make sure we can get a base className to target in vanilla-extract `globalStyle` function. 

Also, return variant definitions (these can be used in documentation for example), so consumers won't have to make abstractions.