### PR TITLE
Add inline variant definitions

### DIFF
--- a/__tests__/responsive-recipes.test.ts
+++ b/__tests__/responsive-recipes.test.ts
@@ -267,6 +267,18 @@ describe('runtime recipes', () => {
         '--height-md__1rdq1cn14': '200px'
       });
     });
+
+    it('should return the inline variants when using the variantDefinitions variants getter', () => {
+      expect(stack.variantDefinitions.inlineVariants).toEqual({
+        width: { values: [], defaultValue: undefined },
+        height: { values: [], defaultValue: undefined }
+      });
+
+      expect(heading.variantDefinitions.inlineVariants).toEqual({
+        width: { values: [], defaultValue: '10px' },
+        height: { values: [], defaultValue: undefined }
+      });
+    });
   });
 
   it('should return a base class when using the className getter', () => {

--- a/src/lib/createRuntimeFn.ts
+++ b/src/lib/createRuntimeFn.ts
@@ -183,22 +183,24 @@ export function createRuntimeFn<
     }
   };
 
-  function getVariantDefinitions(options: Record<string, Record<string, unknown>>) {
-    type VariantDefinitions = {
-      [index: string]: {
-        values: string[];
-        defaultValue?: string;
-      };
+  type VariantDefinitions = {
+    [index: string]: {
+      values: string[];
+      defaultValue?: string;
     };
+  };
+  type Options = Record<string, Record<string, unknown>>;
 
-    return Object.entries(options).reduce<VariantDefinitions>((acc, [key, value]) => {
-      // Note: Should we parse these values here?
-      acc[key] = {
-        values: Object.keys(value),
+  function getVariantDefinitions(options: Options) {
+    const result: VariantDefinitions = {};
+    for (const key in options) {
+      result[key] = {
+        values: Object.keys(options[key] ?? {}),
         defaultValue: buildResult.defaultVariants[key]?.toString()
       };
-      return acc;
-    }, {});
+    }
+
+    return result;
   }
 
   runtimeFn.variantDefinitions = {
@@ -208,6 +210,15 @@ export function createRuntimeFn<
 
     get responsiveVariants() {
       return getVariantDefinitions(buildResult.responsiveVariantClassNames);
+    },
+
+    get inlineVariants() {
+      const options: Options = {};
+      for (const key in buildResult.inlineVariantData) {
+        options[key] = {};
+      }
+
+      return getVariantDefinitions(options);
     },
 
     get defaultVariants() {


### PR DESCRIPTION
```ts
const defs = stack.variantDefinitions.inlineVariants;
```

Of course, inlineVariants do not have values, so the arrays stays empty. API stays the same.